### PR TITLE
Add Plugin::Prefer::BadVersion and Plugin::Prefer::GoodVersion to the See Also section

### DIFF
--- a/lib/Alien/Build/Plugin/Download/Negotiate.pm
+++ b/lib/Alien/Build/Plugin/Download/Negotiate.pm
@@ -298,6 +298,8 @@ sub init
 
 =head1 SEE ALSO
 
+L<Alien::Build::Plugin::Prefer::BadVersion>, L<Alien::Build::Plugin::Prefer::GoodVersion>
+
 L<Alien::Build>, L<alienfile>, L<Alien::Build::MM>, L<Alien>
 
 =cut

--- a/lib/Alien/Build/Plugin/Prefer/BadVersion.pm
+++ b/lib/Alien/Build/Plugin/Prefer/BadVersion.pm
@@ -29,7 +29,7 @@ Filter out any files that match the given version.
  use alienfile;
  plugin 'Prefer::BadVersion' => '1.2.3';
 
-=item as a array
+=item as an array
 
 Filter out all files that match any of the given versions.
 

--- a/lib/Alien/Build/Plugin/Prefer/GoodVersion.pm
+++ b/lib/Alien/Build/Plugin/Prefer/GoodVersion.pm
@@ -30,7 +30,7 @@ Filter any files that match the given version.
  use alienfile;
  plugin 'Prefer::GoodVersion' => '1.2.3';
 
-=item as a array
+=item as an array
 
 Filter all files that match any of the given versions.
 


### PR DESCRIPTION
Plugin::Prefer::BadVersion is useful to know about when there are versions that should be skipped in an alienfile download phase.  

Plugin::Prefer::GoodVersion is listed for symmetry.

The first commit is not really related, but fixes some minor typos.
