### PR TITLE
safer pure-perl pkgconfig with multiple probes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
-  - Fixed a bug where PkgConfig plugins could provide compiler / linker flags when the
-    PkgConfig probe fails, but another probe succeed. (gh#238)
+  - Fixed a bug where Probe and PkgConfig plugins could provide compiler / linker flags
+    when the PkgConfig probe fails, but another probe succeed. (gh#238)
 
 2.35_01   2020-10-28 02:06:21 -0600
   - Added install properties: system_probe_class and system_probe_instance_id (gh#237)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Fixed a bug where PkgConfig plugins could provide compiler / linker flags when the
+    PkgConfig probe fails, but another probe succeed. (gh#238)
 
 2.35_01   2020-10-28 02:06:21 -0600
   - Added install properties: system_probe_class and system_probe_instance_id (gh#237)

--- a/lib/Alien/Build/Plugin/Build/Copy.pm
+++ b/lib/Alien/Build/Plugin/Build/Copy.pm
@@ -46,7 +46,7 @@ with the appropriate logic in your L<alienfile>.
    # alien dist on a platform that doesn't use it.
    requires 'Alien::Build::Plugin::Build::Copy';
  };
-
+ 
  build {
    ...
    if($^O eq 'linux')

--- a/lib/Alien/Build/Plugin/PkgConfig/LibPkgConf.pm
+++ b/lib/Alien/Build/Plugin/PkgConfig/LibPkgConf.pm
@@ -130,6 +130,9 @@ sub init
       my($build) = @_;
       $build->runtime_prop->{legacy}->{name} ||= $pkg_name;
 
+      $build->hook_prop->{probe_class} = __PACKAGE__;
+      $build->hook_prop->{probe_instance_id} = $self->instance_id;
+
       require PkgConfig::LibPkgConf::Client;
       my $client = PkgConfig::LibPkgConf::Client->new;
       my $pkg = $client->find($pkg_name);
@@ -178,6 +181,10 @@ sub init
   $meta->register_hook(
     $_ => sub {
       my($build) = @_;
+
+      return if $build->hook_prop->{name} eq 'gather_system'
+      &&        ($build->install_prop->{system_probe_instance_id} || '') ne $self->instance_id;
+
       require PkgConfig::LibPkgConf::Client;
       my $client = PkgConfig::LibPkgConf::Client->new;
 

--- a/lib/Alien/Build/Plugin/PkgConfig/PP.pm
+++ b/lib/Alien/Build/Plugin/PkgConfig/PP.pm
@@ -132,7 +132,10 @@ sub init
   $meta->register_hook(
     probe => sub {
       my($build) = @_;
+
       $build->runtime_prop->{legacy}->{name} ||= $pkg_name;
+      $build->hook_prop->{probe_class} = __PACKAGE__;
+      $build->hook_prop->{probe_instance_id} = $self->instance_id;
 
       require PkgConfig;
       my $pkg = PkgConfig->find($pkg_name);
@@ -182,6 +185,10 @@ sub init
 
   my $gather = sub {
     my($build) = @_;
+
+    return if $build->hook_prop->{name} eq 'gather_system'
+    &&        ($build->install_prop->{system_probe_instance_id} || '') ne $self->instance_id;
+
     require PkgConfig;
 
     foreach my $name ($pkg_name, @alt_names)

--- a/t/alien_build_plugin_build_copy.t
+++ b/t/alien_build_plugin_build_copy.t
@@ -12,7 +12,7 @@ alien_subtest 'basic' => sub {
     probe sub { 'share' };
 
     share {
-      download sub { 
+      download sub {
         Path::Tiny->new('foo')->touch;
       };
       extract sub {

--- a/t/alien_build_plugin_pkgconfig_commandline.t
+++ b/t/alien_build_plugin_pkgconfig_commandline.t
@@ -558,5 +558,34 @@ alien_subtest 'set env' => sub {
 
 };
 
+alien_subtest 'multiple probes' => sub {
+
+  my $build = alienfile_ok q{
+    use alienfile;
+    plugin 'PkgConfig::CommandLine' => (
+      pkg_name => 'xor',
+      exact_version => '1.2.3',
+    );
+    probe sub { 'system' };
+  };
+
+  alien_install_type_is 'system';
+
+  alien_build_ok;
+
+  is
+    $build,
+    object {
+      call runtime_prop => hash {
+        field cflags        => DNE();
+        field libs          => DNE();
+        field cflags_static => DNE();
+        field libs_static   => DNE();
+        etc;
+      };
+    },
+  ;
+};
+
 done_testing;
 

--- a/t/alien_build_plugin_pkgconfig_libpkgconf.t
+++ b/t/alien_build_plugin_pkgconfig_libpkgconf.t
@@ -447,4 +447,33 @@ alien_subtest 'set env' => sub {
 
 };
 
+alien_subtest 'multiple probes' => sub {
+
+  my $build = alienfile_ok q{
+    use alienfile;
+    plugin 'PkgConfig::LibPkgConf' => (
+      pkg_name => 'xor',
+      exact_version => '1.2.3',
+    );
+    probe sub { 'system' };
+  };
+
+  alien_install_type_is 'system';
+
+  alien_build_ok;
+
+  is
+    $build,
+    object {
+      call runtime_prop => hash {
+        field cflags        => DNE();
+        field libs          => DNE();
+        field cflags_static => DNE();
+        field libs_static   => DNE();
+        etc;
+      };
+    },
+  ;
+};
+
 done_testing;

--- a/t/alien_build_plugin_pkgconfig_pp.t
+++ b/t/alien_build_plugin_pkgconfig_pp.t
@@ -446,9 +446,6 @@ alien_subtest 'multiple probes' => sub {
       };
     },
   ;
-
-  use YAML ();
-  note YAML::Dump($build);
 };
 
 done_testing;

--- a/t/alien_build_plugin_pkgconfig_pp.t
+++ b/t/alien_build_plugin_pkgconfig_pp.t
@@ -419,4 +419,36 @@ alien_subtest 'set env' => sub {
 
 };
 
+alien_subtest 'multiple probes' => sub {
+
+  my $build = alienfile_ok q{
+    use alienfile;
+    plugin 'PkgConfig::PP' => (
+      pkg_name => 'xor',
+      exact_version => '1.2.3',
+    );
+    probe sub { 'system' };
+  };
+
+  alien_install_type_is 'system';
+
+  alien_build_ok;
+
+  is
+    $build,
+    object {
+      call runtime_prop => hash {
+        field cflags        => DNE();
+        field libs          => DNE();
+        field cflags_static => DNE();
+        field libs_static   => DNE();
+        etc;
+      };
+    },
+  ;
+
+  use YAML ();
+  note YAML::Dump($build);
+};
+
 done_testing;

--- a/t/alien_build_plugin_probe_cbuilder.t
+++ b/t/alien_build_plugin_probe_cbuilder.t
@@ -200,13 +200,6 @@ subtest 'fail' => sub {
 
     alien_install_type_is 'system';
 
-    my($out, $err) = capture_merged {
-      eval { $build->build };
-      $@;
-    };
-
-    like $err, qr/cbuilder unable to gather;/;
-
   };
 
 };

--- a/t/alien_build_plugin_probe_cbuilder__live.t
+++ b/t/alien_build_plugin_probe_cbuilder__live.t
@@ -21,7 +21,65 @@ subtest 'live test' => sub {
   alien_build_ok;
   alien_install_type_is 'system';
 
+  is(
+    $build->runtime_prop,
+    hash {
+      field cflags  => '-I/usr/local/include ';
+      field libs    => '-L/usr/local/lib ';
+      etc;
+    },
+  );
+
 };
+
+
+alien_subtest 'multiple probes' => sub {
+
+  require ExtUtils::CBuilder;
+
+  my $build = alienfile_ok q{
+    use alienfile;
+
+    plugin 'Probe::CBuilder' => (
+      cflags => '-I/usr/local/include ',
+      libs   => '-L/usr/local/lib ',
+    );
+
+    probe sub { 'system' };
+
+    my $count = 0;
+    meta->around_hook(probe => sub {
+      my $orig  = shift;
+      my $build = shift;
+      my $type = $orig->($build, @_);
+      if($count++ == 0)
+      {
+        Test2::V0::note("first convert $type to share");
+        return 'share';
+      }
+      else
+      {
+        Test2::V0::note("finally return $type");
+        return $type;
+      }
+    });
+
+  };
+
+  alien_install_type_is 'system';
+  alien_build_ok;
+
+  is(
+    $build->runtime_prop,
+    hash {
+      field cflags  => DNE();
+      field libs    => DNE();
+      etc;
+    },
+  );
+
+};
+
 
 done_testing;
 


### PR DESCRIPTION
This is mainly for `Alien::Libxml2`, which uses multiple probe methods.  In this configuration if one probe or pkg-config plugin fails in the probe step, its gather step may still execute and populate libs cflags, etc.  This patch fixes that oversight.  This should finally put https://github.com/PerlAlien/Alien-Libxml2/issues/23 and similar to bed.

 - [x] `Probe::CBuilder`
 - [x] `Probe::Vcpkg`
 - [x] `PkgConfig::PP`
 - [x] `PkgConfig::LibPkgConf`
 - [x] `PkgConfig::CommandLine`