### PR TITLE
MSYS2-MINGW CI workflow and fixes

### DIFF
--- a/.github/workflows/msys2-mingw.yml
+++ b/.github/workflows/msys2-mingw.yml
@@ -1,0 +1,69 @@
+name: msys2-mingw
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL5LIB: /c/cx/lib/perl5:/c/cx/lib/perl5/MSWin32-x64-multi-thread
+  PERL_LOCAL_LIB_ROOT: c:/cx
+  PERL_MB_OPT: --install_base C:/cx
+  PERL_MM_OPT: INSTALL_BASE=C:/cx
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Perl
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-perl
+
+      - name: perl -V
+        run: |
+          perl -V
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+          ls perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: c:\cx
+          key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+
+      - name: Install Static Dependencies
+        run: |
+          export PATH="/c/cx/bin:$PATH"
+          yes | cpan App::cpanminus || true
+          cpanm -n Dist::Zilla
+          perl -S dzil authordeps --missing | perl -S cpanm -n
+          perl -S dzil listdeps --missing   | perl -S cpanm -n
+      - name: Install Dynamic Dependencies
+        run: |
+          export PATH="/c/cx/bin:$PATH"
+          perl -S dzil run --no-build 'perl -S cpanm --installdeps .'
+      - name: Run Tests
+        run: |
+          export PATH="/c/cx/bin:$PATH"
+          perl -S dzil test -v

--- a/.github/workflows/msys2-mingw.yml
+++ b/.github/workflows/msys2-mingw.yml
@@ -13,6 +13,7 @@ env:
   PERL_LOCAL_LIB_ROOT: c:/cx
   PERL_MB_OPT: --install_base C:/cx
   PERL_MM_OPT: INSTALL_BASE=C:/cx
+  ALIEN_BUILD_PLUGIN_PKGCONFIG_COMMANDLINE_TEST: 1 # Test Alien::Build::Plugin::PkgConfig::CommandLine
 
 jobs:
   perl:

--- a/lib/Alien/Build/Plugin/PkgConfig/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/PkgConfig/CommandLine.pm
@@ -218,8 +218,12 @@ sub init
   if($meta->prop->{platform}->{system_type} eq 'windows-mingw')
   {
     @gather = map {
-      my($pkgconf, @rest) = @$_;
-      [$pkgconf, '--dont-define-prefix', @rest],
+      if(ref $_ eq 'ARRAY') {
+        my($pkgconf, @rest) = @$_;
+        [$pkgconf, '--dont-define-prefix', @rest],
+      } else {
+        $_
+      }
     } @gather;
   }
 

--- a/lib/Test/Alien.pm
+++ b/lib/Test/Alien.pm
@@ -461,7 +461,8 @@ sub xs_ok
   {
     our $count;
     $count = 0 unless defined $count;
-    my $name = sprintf "Test::Alien::XS::Mod%s", $count++;
+    my $name = sprintf "Test::Alien::XS::Mod%s%s", $count, chr(65 + $count % 26 ) x 4;
+    $count++;
     my $code = $xs->{xs};
     $code =~ s{\bTA_MODULE\b}{$name}g;
     $xs->{xs} = $code;


### PR DESCRIPTION
- Add GitHub Actions Workflow for MSYS2/MINGW.
- Only dereference arrayref if arrayref. Otherwise this fails when `@gather` contains a coderef.
- Fix `Test::Alien` module name generation so that `ExtUtils::CBuilder` creates a unique `image-base` address from the DLL name.