### PR TITLE
re-enable the plugins test

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,6 +113,10 @@ jobs:
         run: |
           cip script
 
+      - name: Test Plugins
+        run: |
+          ./maint/cip-test-plugins
+
       - name: CPAN log
         if: ${{ failure() }}
         run: |


### PR DESCRIPTION
These got disabled at some point, but maybe we want to keep them.