### PR TITLE
Quote target to accomodate spaces in Build::Copy

### DIFF
--- a/lib/Alien/Build/Plugin/Build/Copy.pm
+++ b/lib/Alien/Build/Plugin/Build/Copy.pm
@@ -78,7 +78,7 @@ sub init
     $meta->register_hook(build => sub {
       my($build) = @_;
       my $stage = Path::Tiny->new($build->install_prop->{stage})->canonpath;
-      $build->system("xcopy . $stage /E");
+      $build->system(qq{xcopy . "$stage" /E});
     });
   }
   elsif($^O eq 'darwin')
@@ -92,7 +92,7 @@ sub init
     # important enough to care about.
 
     $meta->register_hook(build => [
-      'cp -pPR * %{.install.stage}',
+      'cp -pPR * "%{.install.stage}"',
     ]);
   }
   else
@@ -100,7 +100,7 @@ sub init
     # TODO: some platforms might not support -a
     # I think most platforms will support -r
     $meta->register_hook(build => [
-      'cp -aR * %{.install.stage}',
+      'cp -aR * "%{.install.stage}"',
     ]);
   }
 }


### PR DESCRIPTION
As reported in #290.