### PR TITLE
Add a libs_dynamic() method

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -349,6 +349,20 @@ sub libs {
   return $class->runtime_prop ? $class->_flags('libs') : $class->_pkgconfig_keyword('Libs');
 }
 
+sub libs_dynamic {
+  my $class = shift;
+
+  my $libs = $class->libs;
+  return $libs if !$class->install_type("share");
+  my $dyndir = $class->dynamic_dir;
+  return $libs if !$dyndir;
+  my $d_basename = Path::Tiny->new($dyndir)->basename;
+  my $l_dirname = $class->dist_dir;
+  my $l_basename = 'lib';
+  $libs =~ s<-L${l_dirname}/\K$l_basename><$d_basename>;
+  return $libs;
+}
+
 =head2 libs_static
 
  my $libs = Alien::MyLibrary->libs_static;


### PR DESCRIPTION
When the `alienfile` is using the `Gather::IsolateDynamic` plugin together with configure option `-enable-shared`, the alien client might want to know how to link with the shared version of the library in the "share" install dir.

Background: I am considering submitting a PR to [Alien-GSL](https://github.com/PerlAlien/Alien-GSL) in response to https://github.com/PerlAlien/Alien-GSL/issues/17