### PR TITLE
add atleast_version arg support to Probe::CommandLine and Probe::CBuilder plugins

### DIFF
--- a/lib/Alien/Build/Plugin/Probe/CBuilder.pm
+++ b/lib/Alien/Build/Plugin/Probe/CBuilder.pm
@@ -77,6 +77,14 @@ test program.
 
 has version => undef;
 
+=head2 atleast_version
+
+The minimum required version as provided by the system.
+
+=cut
+
+has 'atleast_version' => undef;
+
 =head2 aliens
 
 List of aliens to query fro compiler and linker flags.
@@ -191,6 +199,14 @@ sub init
       if(defined $self->version)
       {
         my($version) = $out =~ $self->version;
+        if (defined $self->atleast_version)
+        {
+          use Sort::Versions qw( versioncmp );
+          if(versioncmp ($version, $self->atleast_version) < 0)
+          {
+            die "CBuilder probe found version $version, but at least ${ $self->atleast_version } is required.";
+          }
+        }
         $build->hook_prop->{version} = $version;
         $build->install_prop->{plugin_probe_cbuilder_gather}->{$self->instance_id}->{version} = $version;
       }

--- a/lib/Alien/Build/Plugin/Probe/CBuilder.pm
+++ b/lib/Alien/Build/Plugin/Probe/CBuilder.pm
@@ -201,8 +201,8 @@ sub init
         my($version) = $out =~ $self->version;
         if (defined $self->atleast_version)
         {
-          use Sort::Versions qw( versioncmp );
-          if(versioncmp ($version, $self->atleast_version) < 0)
+          require Alien::Base;
+          if(Alien::Base->version_cmp ($version, $self->atleast_version) < 0)
           {
             die "CBuilder probe found version $version, but at least ${ $self->atleast_version } is required.";
           }

--- a/lib/Alien/Build/Plugin/Probe/CBuilder.pm
+++ b/lib/Alien/Build/Plugin/Probe/CBuilder.pm
@@ -204,7 +204,7 @@ sub init
           require Alien::Base;
           if(Alien::Base->version_cmp ($version, $self->atleast_version) < 0)
           {
-            die "CBuilder probe found version $version, but at least ${ $self->atleast_version } is required.";
+            die "CBuilder probe found version $version, but at least @{[ $self->atleast_version ]} is required.";
           }
         }
         $build->hook_prop->{version} = $version;

--- a/lib/Alien/Build/Plugin/Probe/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Probe/CommandLine.pm
@@ -124,19 +124,22 @@ sub init
       die 'Command did not return a true value' if $ret;
       die 'Command output did not match' if defined $self->match && $out !~ $self->match;
       die 'Command standard error did not match' if defined $self->match_stderr && $err !~ $self->match_stderr;
+      my $found_version;
       if(defined $self->version)
       {
         if($out =~ $self->version)
         {
-          $build->runtime_prop->{version} = $1;
+          $found_version = $1;
+          $build->runtime_prop->{version} = $found_version;
         }
       }
       if(defined $self->version_stderr)
       {
         if($err =~ $self->version_stderr)
         {
-          $build->hook_prop->{version} = $1;
-          $build->runtime_prop->{version} = $1;
+          $found_version = $1;
+          $build->hook_prop->{version} = $found_version;
+          $build->runtime_prop->{version} = $found_version;
         }
       }
     }

--- a/lib/Alien/Build/Plugin/Probe/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Probe/CommandLine.pm
@@ -134,7 +134,7 @@ sub init
       die 'Command did not return a true value' if $ret;
       die 'Command output did not match' if defined $self->match && $out !~ $self->match;
       die 'Command standard error did not match' if defined $self->match_stderr && $err !~ $self->match_stderr;
-      if (defined ($self->version // $self->version_stderr))
+      if (defined $self->version or defined $self->version_stderr)
       {
         my $found_version = '0.0.0';
         if(defined $self->version)

--- a/lib/Alien/Build/Plugin/Probe/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Probe/CommandLine.pm
@@ -7,7 +7,6 @@ use Alien::Build::Plugin;
 use Carp ();
 use Capture::Tiny qw( capture );
 use File::Which ();
-use Sort::Versions qw( versioncmp );
 
 # ABSTRACT: Probe for tools or commands already available
 # VERSION
@@ -136,7 +135,7 @@ sub init
       die 'Command standard error did not match' if defined $self->match_stderr && $err !~ $self->match_stderr;
       if (defined $self->version or defined $self->version_stderr)
       {
-        my $found_version = '0.0.0';
+        my $found_version = '0';
         if(defined $self->version)
         {
           if($out =~ $self->version)
@@ -156,7 +155,8 @@ sub init
         }
         if (my $atleast_version = $self->atleast_version)
         {
-          if(versioncmp ($found_version, $self->atleast_version) < 0)
+          require Alien::Base;
+          if(Alien::Base->version_cmp ($found_version, $self->atleast_version) < 0)
           {
             #  reset the versions
             $build->runtime_prop->{version} = undef;

--- a/t/alien_build_plugin_probe_commandline.t
+++ b/t/alien_build_plugin_probe_commandline.t
@@ -186,13 +186,21 @@ subtest 'match + version' => sub {
   };
 
   subtest 'atleast_version satisfied' => sub {
-    my($build) = build(command => 'foo', version => qr/version ([0-9\.]+)/, atleast_version => '0.5.0');
+    my($build) = build(
+      command => 'foo',
+      version => qr/version ([0-9\.]+)/,
+      atleast_version => '0.5.0'
+    );
     is cap { $build->probe }, 'system';
     is $build->runtime_prop->{version}, '1.00';
   };
 
   subtest 'atleast_version not satisfied' => sub {
-    my($build) = build(command => 'foo', version => qr/version ([0-9\.]+)/, atleast_version => '1.5.0');
+    my($build) = build(
+      command => 'foo',
+      version => qr/version ([0-9\.]+)/,
+      atleast_version => '1.5.0'
+    );
     is cap { $build->probe }, 'share';
     is $build->runtime_prop->{version}, undef;
   };

--- a/t/alien_build_plugin_probe_commandline.t
+++ b/t/alien_build_plugin_probe_commandline.t
@@ -185,6 +185,18 @@ subtest 'match + version' => sub {
     is $build->runtime_prop->{version}, undef;
   };
 
+  subtest 'atleast_version satisfied' => sub {
+    my($build) = build(command => 'foo', version => qr/version ([0-9\.]+)/, atleast_version => '0.5.0');
+    is cap { $build->probe }, 'system';
+    is $build->runtime_prop->{version}, '1.00';
+  };
+
+  subtest 'atleast_version not satisfied' => sub {
+    my($build) = build(command => 'foo', version => qr/version ([0-9\.]+)/, atleast_version => '1.5.0');
+    is cap { $build->probe }, 'share';
+    is $build->runtime_prop->{version}, undef;
+  };
+
 };
 
 subtest 'match_stderr + version_stderr' => sub {


### PR DESCRIPTION
Updates #299

Let me know if you want me to rework the commits.  Currently they include some false starts using Sort::Versions which maybe you don't want in the commit history.  



