### PR TITLE
Add Alien::Util, and move version_cmp there

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for {{$dist->name}}
 {{$NEXT}}
   - Added atleast_version to Probe::CommandLine and Probe::CBuilder plugins
     (gh#299, gh#300, shawnlaffan++)
+  - Added Alien::Util module (gh#301)
 
 2.47      2022-03-07 07:03:52 -0700
   - Fixed bug where Probe::CBuilder plugin could report the wrong diagnostic

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -8,6 +8,7 @@ use Path::Tiny ();
 use Scalar::Util qw/blessed/;
 use Capture::Tiny 0.17 qw/capture_stdout/;
 use Text::ParseWords qw/shellwords/;
+use Alien::Util;
 
 # ABSTRACT: Base classes for Alien:: modules
 # VERSION
@@ -443,34 +444,9 @@ behaviour to the C<< <=> >> and C<cmp> operators.
 
 =cut
 
-# Sort::Versions isn't quite the same algorithm because it differs in
-# behaviour with leading zeroes.
-#   See also  https://dev.gentoo.org/~mgorny/pkg-config-spec.html#version-comparison
 sub version_cmp {
   shift;
-  my @x = (shift =~ m/([0-9]+|[a-z]+)/ig);
-  my @y = (shift =~ m/([0-9]+|[a-z]+)/ig);
-
-  while(@x and @y) {
-    my $x = shift @x; my $x_isnum = $x =~ m/[0-9]/;
-    my $y = shift @y; my $y_isnum = $y =~ m/[0-9]/;
-
-    if($x_isnum and $y_isnum) {
-      # Numerical comparison
-      return $x <=> $y if $x != $y;
-    }
-    elsif(!$x_isnum && !$y_isnum) {
-      # Alphabetic comparison
-      return $x cmp $y if $x ne $y;
-    }
-    else {
-      # Of differing types, the numeric one is newer
-      return $x_isnum - $y_isnum;
-    }
-  }
-
-  # Equal so far; the longer is newer
-  return @x <=> @y;
+  goto &Alien::Util::version_cmp;
 }
 
 =head2 install_type
@@ -1161,4 +1137,3 @@ For graciously teaching me about rpath and dynamic loading,
 =back
 
 =cut
-

--- a/lib/Alien/Build/Plugin.pm
+++ b/lib/Alien/Build/Plugin.pm
@@ -286,3 +286,4 @@ sub prop
 L<Alien::Build>, L<alienfile>, L<Alien::Build::Manual::PluginAuthor>
 
 =cut
+

--- a/lib/Alien/Build/Plugin/Probe/CBuilder.pm
+++ b/lib/Alien/Build/Plugin/Probe/CBuilder.pm
@@ -7,6 +7,7 @@ use Alien::Build::Plugin;
 use File::chdir;
 use File::Temp ();
 use Capture::Tiny qw( capture_merged capture );
+use Alien::Util qw( version_cmp );
 
 # ABSTRACT: Probe for system libraries by guessing with ExtUtils::CBuilder
 # VERSION
@@ -201,8 +202,7 @@ sub init
         my($version) = $out =~ $self->version;
         if (defined $self->atleast_version)
         {
-          require Alien::Base;
-          if(Alien::Base->version_cmp ($version, $self->atleast_version) < 0)
+          if(version_cmp ($version, $self->atleast_version) < 0)
           {
             die "CBuilder probe found version $version, but at least @{[ $self->atleast_version ]} is required.";
           }

--- a/lib/Alien/Build/Plugin/Probe/CommandLine.pm
+++ b/lib/Alien/Build/Plugin/Probe/CommandLine.pm
@@ -7,6 +7,7 @@ use Alien::Build::Plugin;
 use Carp ();
 use Capture::Tiny qw( capture );
 use File::Which ();
+use Alien::Util qw( version_cmp );
 
 # ABSTRACT: Probe for tools or commands already available
 # VERSION
@@ -155,8 +156,7 @@ sub init
         }
         if (my $atleast_version = $self->atleast_version)
         {
-          require Alien::Base;
-          if(Alien::Base->version_cmp ($found_version, $self->atleast_version) < 0)
+          if(version_cmp ($found_version, $self->atleast_version) < 0)
           {
             #  reset the versions
             $build->runtime_prop->{version} = undef;

--- a/lib/Alien/Util.pm
+++ b/lib/Alien/Util.pm
@@ -1,0 +1,73 @@
+package Alien::Util;
+
+use strict;
+use warnings;
+use Exporter qw( import );
+
+# ABSTRACT: Alien Utilities used at build and runtime
+# VERSION
+
+=head1 SYNOPSIS
+
+ use Alien::Util qw( version_cmp );
+
+=head1 DESCRIPTION
+
+This module contains some functions used by both the L<Alien::Build> build-time and <Alien::Base>
+run-time for Alien.
+
+=cut
+
+our @EXPORT_OK = qw( version_cmp );
+
+=head2 version_cmp
+
+  $cmp = version_cmp($x, $y)
+
+Comparison method used by L<atleast_version>, L<exact_version> and
+L<max_version>. May be useful to implement custom comparisons, or for
+subclasses to overload to get different version comparison semantics than the
+default rules, for packages that have some other rules than the F<pkg-config>
+behaviour.
+
+Should return a number less than, equal to, or greater than zero; similar in
+behaviour to the C<< <=> >> and C<cmp> operators.
+
+=cut
+
+# Sort::Versions isn't quite the same algorithm because it differs in
+# behaviour with leading zeroes.
+#   See also  https://dev.gentoo.org/~mgorny/pkg-config-spec.html#version-comparison
+sub version_cmp {
+  my @x = (shift =~ m/([0-9]+|[a-z]+)/ig);
+  my @y = (shift =~ m/([0-9]+|[a-z]+)/ig);
+
+  while(@x and @y) {
+    my $x = shift @x; my $x_isnum = $x =~ m/[0-9]/;
+    my $y = shift @y; my $y_isnum = $y =~ m/[0-9]/;
+
+    if($x_isnum and $y_isnum) {
+      # Numerical comparison
+      return $x <=> $y if $x != $y;
+    }
+    elsif(!$x_isnum && !$y_isnum) {
+      # Alphabetic comparison
+      return $x cmp $y if $x ne $y;
+    }
+    else {
+      # Of differing types, the numeric one is newer
+      return $x_isnum - $y_isnum;
+    }
+  }
+
+  # Equal so far; the longer is newer
+  return @x <=> @y;
+}
+
+1;
+
+=head1 SEE ALSO
+
+L<Alien::Base>, L<alienfile>, L<Alien::Build>
+
+=cut

--- a/t/alien_util.t
+++ b/t/alien_util.t
@@ -1,8 +1,14 @@
 use 5.008004;
 use Test2::V0 -no_srand => 1;
+use Alien::Util qw( version_cmp );
 
-diag 'TODO';
 
-ok 1;
+subtest 'version_cmp' => sub {
+
+  is( version_cmp('1.0.1', '1.0.1'), 0 );
+  is( version_cmp('1.0.1', '1.0.2'), -1 );
+  is( version_cmp('1.0.1', '1.0.0'), 1 );
+
+};
 
 done_testing;

--- a/t/alien_util.t
+++ b/t/alien_util.t
@@ -1,0 +1,8 @@
+use 5.008004;
+use Test2::V0 -no_srand => 1;
+
+diag 'TODO';
+
+ok 1;
+
+done_testing;


### PR DESCRIPTION
This PR adds an `Alien::Util` module for things that are needed by both the `Alien::Base` runtime and `Alien::Build` build-time without either having to depend on the other.  So far the only function is `version_cmp`, which used to live in `Alien::Base` as a class method, but was used in some of the probe plugins with #300 

- [x] Add actual tests in `t/alien_util.t`