### PR TITLE
Fix support for systems without a compiler

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-1-release-amd64
+  image: freebsd-13-0-release-amd64
 
 task:
   install_script:

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Fix tests to pass on systems that do not have a compiler (gh#309)
 
 2.48      2022-03-13 11:20:19 -0600
   - Added atleast_version to Probe::CommandLine and Probe::CBuilder plugins

--- a/lib/Alien/Base/Wrapper.pm
+++ b/lib/Alien/Base/Wrapper.pm
@@ -183,6 +183,9 @@ sub new
       $libs   = $alien->libs;
     }
 
+    $cflags = '' unless defined $cflags;
+    $libs = '' unless defined $libs;
+
     push @cflags_I,     grep  /^-I/, shellwords $cflags;
     push @cflags_other, grep !/^-I/, shellwords $cflags;
 

--- a/t/lib/MyTest/HaveCompiler.pm
+++ b/t/lib/MyTest/HaveCompiler.pm
@@ -1,0 +1,24 @@
+package MyTest::HaveCompiler;
+
+use strict;
+use warnings;
+use Test2::V0 ();
+use Capture::Tiny qw( capture_merged );
+use parent qw( Exporter );
+
+our @EXPORT_OK = qw( require_compiler );
+
+{
+  my $first = 1;
+  sub require_compiler
+  {
+    my $skip;
+    my($diag) = capture_merged {
+        $skip = !ExtUtils::CBuilder->new->have_compiler;
+    };
+    Test2::V0::note $diag if defined $diag && $diag ne '';
+    Test2::V0::skip_all 'test requires a compiler' if $skip;
+  }
+}
+
+1;

--- a/t/test_alien.t
+++ b/t/test_alien.t
@@ -1,5 +1,6 @@
 use 5.008004;
 use lib 'corpus/lib';
+use lib 't/lib';
 use Test2::V0 -no_srand => 1;
 use Test::Alien;
 use Alien::Foo;
@@ -10,6 +11,7 @@ use Alien::Build::Util qw( _dump );
 use List::Util 1.33 qw( any );
 use Config;
 use Test2::API 1.302096 ();
+use MyTest::HaveCompiler qw( require_compiler );
 
 sub _reset
 {
@@ -365,9 +367,7 @@ subtest 'ffi_ok' => sub {
 
 subtest 'xs_ok' => sub {
 
-  skip_all 'test requires a compiler'
-    unless ExtUtils::CBuilder->new->have_compiler;
-
+  require_compiler();
   _reset();
 
   alien_ok synthetic {};
@@ -743,6 +743,7 @@ subtest 'with_subtest SEGV' => sub {
 subtest 'diagnostic when calling tools without alien_ok' => sub {
 
   _reset();
+  require_compiler;
 
   my $xs = <<'EOF';
 #include "EXTERN.h"

--- a/t/test_alien_cancompile.t
+++ b/t/test_alien_cancompile.t
@@ -2,12 +2,19 @@ use 5.008004;
 use Test2::V0 -no_srand => 1;
 use Test::Alien::CanCompile ();
 use ExtUtils::CBuilder;
+use Capture::Tiny qw( capture_merged );
 
 subtest 'unmocked' => sub {
-    is(
+
+    my($diag, $ta_cc_skip, $eucb_have_compiler) = capture_merged {
       !!Test::Alien::CanCompile->skip,
-      !ExtUtils::CBuilder->new->have_compiler,
-      'skip'
+      !!ExtUtils::CBuilder->new->have_compiler,
+    };
+    note $diag;
+
+    is(
+      $ta_cc_skip, !$eucb_have_compiler,
+      'skip computed by Test::Alien::CanCompile should match ExtUtils::CBuilder#have_compiler'
     );
 };
 


### PR DESCRIPTION
A test that really does require a compiler slipped through the screen.  I've also silenced a few warnings, though others still remain.