### PR TITLE
Fix undef flags causing warning in new Text::ParseWords

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -277,6 +277,7 @@ sub _flags
 
   my $config = $class->runtime_prop;
   my $flags = $config->{$key};
+  defined($flags) or return '';
 
   my $prefix = $config->{prefix};
   $prefix =~ s{\\}{/}g if $^O =~ /^(MSWin32|msys)$/;


### PR DESCRIPTION
This fix to `Alien::Base` prevents `_flags` from passing `undef` to `split_flags`.

In the case of `split_flags_unix` passing `undef` produces a warning in `Text::ParseWords::shellwords`: "Use of uninitialized value $line in substitution (s///) at 5.36.0/Text/ParseWords.pm line 21." The warning only occurs with `Text::ParseWords` 3.31 or higher as it previously did not have `use warnings;` on. Perl 5.36 shipped with `Text::ParseWords` 3.31.

The fix was made in `_flags` so that other implementations of `split_flags` would be guarded though I do not know if `undef` causes any issues with them.

The issue presented itself when attempting a `sys` Alien installation without setting cflags on 5.36: Example [Alien::libFLAC](https://github.com/G4Vi/MHFS/blob/9f11198b1d7a5d34ba780112cc5fa7ca3e1047ab/Alien-libFLAC/alienfile)