### PR TITLE
Add autoreconf helper to Autoconf plugin

### DIFF
--- a/author.yml
+++ b/author.yml
@@ -152,6 +152,7 @@ pod_spelling_system:
     - kon
     - INPHOBIA
     - nauwelaerts
+    - autoreconf
 
 pod_coverage:
   skip: 0

--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -224,6 +224,23 @@ Some reasonable default flags will be provided.
     },
   );
 
+=head2 autoreconf
+
+ %{autoreconf}
+
+If you don't have a C<configure> script but do have a C<configure.ac>, use this
+helper to produce a C<configure> script, and then run the C<%{configure}>
+helper.
+
+=cut
+
+  $intr->add_helper(
+    autoreconf => sub {
+        my $autoreconf = _win ? 'sh autoreconf' : 'autoreconf';
+        $autoreconf;
+    },
+  );
+
   $meta->default_hook(
     build => [
       '%{configure} --disable-shared',

--- a/t/alien_build_plugin_build_autoconf.t
+++ b/t/alien_build_plugin_build_autoconf.t
@@ -24,10 +24,10 @@ subtest 'basic' => sub {
 
   my $autoreconf = $meta->interpolator->interpolate('%{autoreconf}');
   isnt $autoreconf, '', "\%{autoreconf} = $autoreconf";
-  is $autoreconf, 'autoreconf';
+  like $autoreconf, qr{autoreconf};
 
   my $autoreconf_opts = $meta->interpolator->interpolate('%{autoreconf} -if --warnings=all');
-  is $autoreconf_opts, 'autoreconf -if --warnings=all';
+  like $autoreconf_opts, qr{autoreconf -if --warnings=all};
 
   is($build->meta_prop->{destdir}, 1);
   is($meta->prop->{destdir}, 1);

--- a/t/alien_build_plugin_build_autoconf.t
+++ b/t/alien_build_plugin_build_autoconf.t
@@ -22,6 +22,13 @@ subtest 'basic' => sub {
   like $configure, qr{configure};
   like $configure, qr{--with-pic};
 
+  my $autoreconf = $meta->interpolator->interpolate('%{autoreconf}');
+  isnt $autoreconf, '', "\%{autoreconf} = $autoreconf";
+  is $autoreconf, 'autoreconf';
+
+  my $autoreconf_opts = $meta->interpolator->interpolate('%{autoreconf} -if --warnings=all');
+  is $autoreconf_opts, 'autoreconf -if --warnings=all';
+
   is($build->meta_prop->{destdir}, 1);
   is($meta->prop->{destdir}, 1);
 };


### PR DESCRIPTION
I found myself needing something like this to support an upstream library that doesn't ship a `./configure` script, but instead ships an `autogen.sh` script that calls `autoreconf` with these options. If there's a better way to do this, I'm open to the idea.

My `alienfile` looks like this:

```
plugin 'PkgConfig' => (
  pkg_name => 'libdogecoin',
);

share {
  start_url 'https://github.com/dogecoinfoundation/libdogecoin/archive/refs/tags/v0.1.0.tar.gz';
  plugin 'Download';
  plugin 'Extract' => 'tar.gz';
  plugin 'Build::Autoconf';
  build [
    '%{autoreconf} -if --warnings=all',
    '%{configure} --disable-shared',
    '%{make}',
    '%{make} install',
  ];
};
```

All tests pass for me on 64-bit x86 Linux.