### PR TITLE
remove subplugin method

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - removed long deprecated subplugin method from Alien::Build::Plugin (gh#331)
 
 2.56      2022-08-13 15:33:18 -0600
   - Production release identical to 2.55.01

--- a/author.yml
+++ b/author.yml
@@ -41,7 +41,6 @@ pod_spelling_system:
     - unixy
     - microsoft
     - GnuWin
-    - subplugin
     - alienizing
     - libfoo
     - libpkgconf

--- a/lib/Alien/Build/Plugin.pm
+++ b/lib/Alien/Build/Plugin.pm
@@ -173,41 +173,6 @@ sub import
   { no strict 'refs'; *{ "${caller}::has" } = $has }
 }
 
-=head2 subplugin
-
-B<DEPRECATED>: Maybe removed, but not before 1 October 2018.
-
- my $plugin2 = $plugin1->subplugin($plugin_name, %args);
-
-Finds the given plugin and loads it (unless already loaded) and creats a
-new instance and returns it.  Most useful from a Negotiate plugin,
-like this:
-
- sub init
- {
-   my($self, $meta) = @_;
-   $self->subplugin(
-     'Foo::Bar',  # loads Alien::Build::Plugin::Foo::Bar,
-                  # or throw exception
-     foo => 1,    # these key/value pairs passsed into new
-     bar => 2,    # for the plugin instance.
-   )->init($meta);
- }
-
-=cut
-
-sub subplugin
-{
-  my(undef, $name, %args) = @_;
-  Carp::carp("subplugin method is deprecated");
-  my $class = "Alien::Build::Plugin::$name";
-  my $pm = "$class.pm";
-  $pm =~ s/::/\//g;
-  require $pm unless eval { $class->can('new') };
-  delete $args{$_} for grep { ! defined $args{$_} } keys %args;
-  $class->new(%args);
-}
-
 =head2 has
 
  has $prop_name;

--- a/t/alien_build_plugin.t
+++ b/t/alien_build_plugin.t
@@ -48,39 +48,6 @@ subtest 'properties' => sub {
 
 };
 
-subtest 'subplugin' => sub {
-
-  {
-    package
-      Alien::Build::Plugin::Foo::Bar;
-    use Alien::Build::Plugin;
-
-    has foo => undef;
-    has bar => 2;
-
-    sub init
-    {
-      my($self,$meta) = @_;
-    }
-  }
-
-  my $plugin1 = Alien::Build::Plugin::RogerRamjet->new;
-  my $plugin2;
-  is(
-    warnings { $plugin2 = $plugin1->subplugin('Foo::Bar', foo => 1, bar => undef) },
-    array {
-      item match qr/subplugin method is deprecated/;
-      end;
-    },
-    'warns',
-  );
-  isa_ok $plugin2, 'Alien::Build::Plugin';
-  isa_ok $plugin2, 'Alien::Build::Plugin::Foo::Bar';
-  is $plugin2->foo, 1;
-  is $plugin2->bar, 2;
-
-};
-
 subtest 'instance-id' => sub {
 
   {


### PR DESCRIPTION
This was deprecated fairly early on, and was never used widely.