### PR TITLE
test more plugins in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,9 +27,6 @@ jobs:
             tag: "5.36-bionic"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.36-centos7"
-          - alien_build_install_extra: 1
-            env: ALIEN_BUILD_LIVE_TEST=1
             tag: "5.36-fedora36"
           - alien_build_install_extra: 0
             env: ALIEN_BUILD_LIVE_TEST=0
@@ -37,6 +34,9 @@ jobs:
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
             tag: "5.36-bullseye"
+          - alien_build_install_extra: 1
+            env: ALIEN_DOWNLOAD_RULE=warn
+            tag: "5.36"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=digest
             tag: "5.36"

--- a/maint/ci-test-plugins.pl
+++ b/maint/ci-test-plugins.pl
@@ -24,17 +24,37 @@ die "not exactly one tarball: @tarball" if @tarball != 1;
 my $tarball = shift @tarball;
 run 'cpanm', '-n', $tarball;
 
+my %min = (
+  'Alien::Build::Plugin::Extract::Libarchive' => 5.020
+);
+
+# TODO: Alien::Build::Plugin::Download::GitHub
+
 my @mods = qw(
   Alien::Build::MB
+  Alien::Build::Git
+  Alien::Role::Dino
   Alien::Build::Plugin::Build::Premake5
   Alien::Build::Plugin::Decode::SourceForge
-  Alien::Build::Plugin::Probe::Override
+  Alien::Build::Plugin::Cleanse::BuildDir
+  Alien::Build::Plugin::Extract::Libarchive
+  Alien::Build::Plugin::Fetch::Cache
+  Alien::Build::Plugin::Fetch::HostAllowList
+  Alien::Build::Plugin::Fetch::HostBlockList
   Alien::Build::Plugin::Fetch::Prompt
+  Alien::Build::Plugin::PkgConfig::PPWrapper
+  Alien::Build::Plugin::Probe::GnuWin32
+  Alien::Build::Plugin::Probe::Override
   Alien::Build::Plugin::Fetch::Rewrite
 );
 
 foreach my $mod (@mods)
 {
+  my $min = $min{$mod};
+  if(defined $min)
+  {
+    next unless $] >= $min;
+  }
   {
     local $ENV{ALIEN_DOWNLOAD_RULE} = 'default';
     local $ENV{ALIEN_INSTALL_TYPE} = 'default';

--- a/maint/cip-before-install
+++ b/maint/cip-before-install
@@ -7,27 +7,21 @@ if echo $CIP_TAG | grep -q -- -alpine ; then
   cip sudo apk add cmake
   cip sudo apk add pkgconf-dev
   cip sudo apk add libffi-dev
-elif  echo $CIP_TAG | grep -q -- -centos ; then
-  echo CentOS
-  cip sudo yum install libffi-devel wget -y
+  # needed for plugin tests later
+  cip sudo apk add git
+  cip sudo apk add g++
 elif echo $CIP_TAG | grep -q -- -fedora ; then
   echo Fedora
-  cip sudo yum install cmake libffi-devel wget -y
+  cip sudo yum install cmake libffi-devel wget git g++ -y
 else
   echo Debian or Ubuntu
   cip sudo apt-get update
-  cip sudo apt-get -y install pkg-config cmake libffi-dev wget
+  cip sudo apt-get -y install pkg-config cmake libffi-dev wget git g++
 fi
 
 if [ "x$ALIEN_BUILD_INSTALL_EXTRA" == "x1" ]; then
 
-  if echo $CIP_TAG | grep -q -- -centos ; then
-    echo 'skipping cmake3 on CentOS 7'
-    # CentOS 7 comes with a 2.x cmake, which doesn't fools Alt::Alien::cmake3::System
-    # and doesn't work with our test suite
-  else
-    cip exec env PERL_ALT_INSTALL=OVERWRITE cpanm -n Alt::Alien::cmake3::System
-  fi
+  cip exec env PERL_ALT_INSTALL=OVERWRITE cpanm -n Alt::Alien::cmake3::System
 
   cip exec cpanm -n \
     Test2::Harness \

--- a/t/alien_build_plugin_fetch_curlcommand.t
+++ b/t/alien_build_plugin_fetch_curlcommand.t
@@ -226,23 +226,11 @@ subtest 'fetch from http' => sub {
 subtest 'live test' => sub {
   skip_all 'set ALIEN_BUILD_LIVE_TEST=1 to enable test' unless $ENV{ALIEN_BUILD_LIVE_TEST};
 
-  if(defined $ENV{CIPDIST} && $ENV{CIPDIST} eq 'centos6')
-  {
-    my $curl = which('curl');
-    is $curl, T();
-    note "curl = $curl";
-    my $pok = Alien::Build::Plugin::Fetch::CurlCommand->protocol_ok('https');
-    is $pok, F();
-    return;
-  }
-  else
-  {
-    my $curl = which('curl');
-    is $curl, T();
-    note "curl = $curl";
-    my $pok = Alien::Build::Plugin::Fetch::CurlCommand->protocol_ok('https');
-    is $pok, T();
-  }
+  my $curl = which('curl');
+  is $curl, T();
+  note "curl = $curl";
+  my $pok = Alien::Build::Plugin::Fetch::CurlCommand->protocol_ok('https');
+  is $pok, T();
 
   require Alien::Build::Plugin::Download::Negotiate;
   my $mock = mock 'Alien::Build::Plugin::Download::Negotiate' => (


### PR DESCRIPTION
 - [x] Alien::Build::Git (https://github.com/PerlAlien/Alien-Build-Git/pull/11)
 - [x] Alien::Role::Dino (https://github.com/PerlAlien/Alien-Role-Dino/pull/10)
 - [x] Alien::Build::Plugin::Cleanse::BuildDir (https://github.com/shawnlaffan/Alien-Build-Plugin-Cleanse-BuildDir/pull/2)
 - [ ] Alien::Build::Plugin::Download::GitHub (https://github.com/PerlAlien/Alien-Build-Plugin-Download-GitHub/pull/18)
 - [x] Alien::Build::Plugin::Extract::Libarchive (requires a fairly recent Perl!) (https://github.com/PerlAlien/Alien-Build-Plugin-Extract-Libarchive/pull/4)
 - [x] Alien::Build::Plugin::Fetch::Cache (https://github.com/PerlAlien/Alien-Build-Plugin-Fetch-Cache/pull/4)
 - [x] Alien::Build::Plugin::Fetch::HostAllowList
 - [x] Alien::Build::Plugin::Fetch::HostBlockList
 - [x] Alien::Build::Plugin::PkgConfig::PPWrapper
 - [x] Alien::Build::Plugin::Probe::GnuWin32