### PR TITLE
Add CPU properties for count and architecture name

### DIFF
--- a/author.yml
+++ b/author.yml
@@ -154,6 +154,7 @@ pod_spelling_system:
     - cryptographic
     - TLS
     - aggresive
+    - CPUs
 
 pod_coverage:
   skip: 0

--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -465,6 +465,41 @@ Contains a non-negative integer of available (possibly virtual) CPUs on the
 system. This can be used by build plugins to build in parallel. The environment
 variable C<ALIEN_CPU_COUNT> can be set to override the CPU count.
 
+=item platform.cpu.arch.name
+
+Contains a normalized name for the architecture of the current Perl. This can
+be used by fetch plugins to determine which binary packages to download.
+The value may be one of the following, but this list will be expanded as
+needed.
+
+=over 4
+
+=item C<armel>
+
+32-bit ARM soft-float
+
+=item C<armhf>
+
+32-bit ARM hard-float
+
+=item C<aarch64>
+
+64-bit ARM
+
+=item C<x86>
+
+32-bit Intel (i386, i486, i686)
+
+=item C<x86_64>
+
+64-bit Intel (AMD64)
+
+=item C<unknown>
+
+Unable to detect architecture. Please report this if needed.
+
+=back
+
 =back
 
 =item out_of_source

--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -459,6 +459,12 @@ but others may be added in the future.
 Note that C<cygwin> and C<msys> are considered C<unix> even though they run
 on windows!
 
+=item platform.cpu.count
+
+Contains a non-negative integer of available (possibly virtual) CPUs on the
+system. This can be used by build plugins to build in parallel. The environment
+variable C<ALIEN_CPU_COUNT> can be set to override the CPU count.
+
 =back
 
 =item out_of_source

--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -486,6 +486,14 @@ needed.
 
 64-bit ARM
 
+=item C<ppc>
+
+32-bit PowerPC (big-endian)
+
+=item C<ppc64>
+
+64-bit PowerPC (big-endian)
+
 =item C<x86>
 
 32-bit Intel (i386, i486, i686)

--- a/lib/Alien/Build/Plugin/Core/Setup.pm
+++ b/lib/Alien/Build/Plugin/Core/Setup.pm
@@ -83,6 +83,111 @@ sub _platform
   {
     $hash->{system_type} = 'unix';
   }
+
+  $hash->{cpu}{count} =
+    exists $ENV{ALIEN_CPU_COUNT} && $ENV{ALIEN_CPU_COUNT} > 0
+    ? $ENV{ALIEN_CPU_COUNT}
+    : _cpu_count();
+}
+
+# Retrieve number of available CPU cores. Adopted from
+# <https://metacpan.org/release/MARIOROY/MCE-1.879/source/lib/MCE/Util.pm#L49>
+# which is in turn adopted from Test::Smoke::Util with improvements.
+sub _cpu_count {
+  local $ENV{PATH} = $ENV{PATH};
+  if( $^O ne 'MSWin32' ) {
+    $ENV{PATH} = "/usr/sbin:/sbin:/usr/bin:/bin:$ENV{PATH}";
+  }
+  $ENV{PATH} =~ /(.*)/; $ENV{PATH} = $1;   ## Remove tainted'ness
+
+  my $ncpu = 1;
+
+  OS_CHECK: {
+    local $_ = lc $^O;
+
+    /linux/ && do {
+      my ( $count, $fh );
+      if ( open $fh, '<', '/proc/stat' ) {
+        $count = grep { /^cpu\d/ } <$fh>;
+        close $fh;
+      }
+      $ncpu = $count if $count;
+      last OS_CHECK;
+    };
+
+    /bsd|darwin|dragonfly/ && do {
+      chomp( my @output = `sysctl -n hw.ncpu 2>/dev/null` );
+      $ncpu = $output[0] if @output;
+      last OS_CHECK;
+    };
+
+    /aix/ && do {
+      my @output = `lparstat -i 2>/dev/null | grep "^Online Virtual CPUs"`;
+      if ( @output ) {
+        $output[0] =~ /(\d+)\n$/;
+        $ncpu = $1 if $1;
+      }
+      if ( !$ncpu ) {
+        @output = `pmcycles -m 2>/dev/null`;
+        if ( @output ) {
+          $ncpu = scalar @output;
+        } else {
+          @output = `lsdev -Cc processor -S Available 2>/dev/null`;
+          $ncpu = scalar @output if @output;
+        }
+      }
+      last OS_CHECK;
+    };
+
+    /gnu/ && do {
+      chomp( my @output = `nproc 2>/dev/null` );
+      $ncpu = $output[0] if @output;
+      last OS_CHECK;
+    };
+
+    /haiku/ && do {
+      my @output = `sysinfo -cpu 2>/dev/null | grep "^CPU #"`;
+      $ncpu = scalar @output if @output;
+      last OS_CHECK;
+    };
+
+    /hp-?ux/ && do {
+      my $count = grep { /^processor/ } `ioscan -fkC processor 2>/dev/null`;
+      $ncpu = $count if $count;
+      last OS_CHECK;
+    };
+
+    /irix/ && do {
+      my @out = grep { /\s+processors?$/i } `hinv -c processor 2>/dev/null`;
+      $ncpu = (split ' ', $out[0])[0] if @out;
+      last OS_CHECK;
+    };
+
+    /osf|solaris|sunos|svr5|sco/ && do {
+      if (-x '/usr/sbin/psrinfo') {
+        my $count = grep { /on-?line/ } `psrinfo 2>/dev/null`;
+        $ncpu = $count if $count;
+      }
+      else {
+        my @output = grep { /^NumCPU = \d+/ } `uname -X 2>/dev/null`;
+        $ncpu = (split ' ', $output[0])[2] if @output;
+      }
+      last OS_CHECK;
+    };
+
+    /mswin|mingw|msys|cygwin/ && do {
+      if (exists $ENV{NUMBER_OF_PROCESSORS}) {
+        $ncpu = $ENV{NUMBER_OF_PROCESSORS};
+      }
+      last OS_CHECK;
+    };
+
+    warn "CPU count: unknown operating system";
+  }
+
+  $ncpu = 1 if (!$ncpu || $ncpu < 1);
+
+  $ncpu;
 }
 
 1;

--- a/t/alien_build_plugin_core_setup.t
+++ b/t/alien_build_plugin_core_setup.t
@@ -2,6 +2,7 @@ use 5.008004;
 use Test2::V0 -no_srand => 1;
 use Test::Alien::Build;
 use Alien::Build::Plugin::Core::Setup;
+use Alien::Build::Util qw( _dump );
 
 subtest 'compiler type' => sub {
 
@@ -48,6 +49,16 @@ subtest 'CPU count' => sub {
       cmp_ok( $cpu_count, '>', 0, "ALIEN_CPU_COUNT=0 is ignored (value: $cpu_count)" );
     };
   };
+};
+
+subtest 'CPU arch' => sub {
+
+  my $build = alienfile_ok q{
+    use alienfile;
+  };
+
+  ok( $build->meta_prop->{platform}->{cpu}{arch}, 'has a CPU arch' );
+  note "CPU arch:\n@{[ _dump($build->meta_prop->{platform}->{cpu}{arch}) ]}";
 };
 
 done_testing;

--- a/t/alien_build_plugin_core_setup.t
+++ b/t/alien_build_plugin_core_setup.t
@@ -13,4 +13,41 @@ subtest 'compiler type' => sub {
   note "compiler type = @{[ $build->meta_prop->{platform}->{compiler_type} ]}";
 };
 
+subtest 'CPU count' => sub {
+
+  my $build = alienfile_ok q{
+    use alienfile;
+  };
+
+  ok( $build->meta_prop->{platform}->{cpu}{count}, 'has a CPU count' );
+  cmp_ok( $build->meta_prop->{platform}->{cpu}{count}, '>', '0',
+    'CPU count is non-negative' );
+  note "CPU count = @{[ $build->meta_prop->{platform}->{cpu}{count} ]}";
+
+  subtest "ALIEN_CPU_COUNT environment variable" => sub {
+    subtest "ALIEN_CPU_COUNT=1" => sub {
+      local $ENV{ALIEN_CPU_COUNT} = 1;
+      my $build = alienfile_ok q{
+        use alienfile;
+      };
+      is( $build->meta_prop->{platform}->{cpu}{count}, 1, 'CPU count = 1' );
+    };
+    subtest "ALIEN_CPU_COUNT=2" => sub {
+      local $ENV{ALIEN_CPU_COUNT} = 2;
+      my $build = alienfile_ok q{
+        use alienfile;
+      };
+      is( $build->meta_prop->{platform}->{cpu}{count}, 2, 'CPU count = 2' );
+    };
+    subtest "ALIEN_CPU_COUNT=0" => sub {
+      local $ENV{ALIEN_CPU_COUNT} = 0;
+      my $build = alienfile_ok q{
+        use alienfile;
+      };
+      my $cpu_count = $build->meta_prop->{platform}->{cpu}{count};
+      cmp_ok( $cpu_count, '>', 0, "ALIEN_CPU_COUNT=0 is ignored (value: $cpu_count)" );
+    };
+  };
+};
+
 done_testing;


### PR DESCRIPTION
## CPU count

Adds a pure Perl implementation for checking the number of available CPUs.

I have not yet added support for this to `::Build::Make`, but I can see adding
the appropriate flag (e.g., `-j`) being enabled automatically (which will
sometimes show upstream bugs if the upstream that is being built does not
specify dependencies properly)

## CPU arch name

Detects the most common architectures and maps them to common names (roughly
the names of Debian ports).  I'm leaving room for possible future extensions
such as adding ARM versions as another property if needed.

Leaving out `mips`, `mipsel`, `mips64el`, `ppc64el`, `s390x` for now as I
rarely see pre-compiled binaries for those distributed now.

I decided against adding GPU/integrated graphics hardware vendor/capabilities
detection (e.g., Nvidia CUDA) as that is more involved and not every package needs
that. I'll create a separate distribution for that.
