### PR TITLE
better diagnostic when filter excludes all

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Improved diagnostic when all links are excluded by the filter
+    stage (gh#380)
 
 2.71      2022-10-04 11:18:14 -0600
   - Added Alien::Build::Plugin::Extract::File (gh#375)

--- a/lib/Alien/Build/Plugin/Core/Download.pm
+++ b/lib/Alien/Build/Plugin/Core/Download.pm
@@ -41,6 +41,7 @@ sub _hook
 
   if($res->{type} eq 'list')
   {
+    my $orig = $res;
     $res = $build->prefer($res);
 
     my @exclude;
@@ -54,7 +55,25 @@ sub _hook
       } @{ $res->{list} };
     }
 
-    die "no matching files in listing" if @{ $res->{list} } == 0;
+    if(@{ $res->{list} } == 0)
+    {
+      my @excluded = map { $_->{url} } @{ $orig->{list} };
+      if(@excluded)
+      {
+        if(@excluded > 15)
+        {
+          splice @excluded , 14;
+          push @excluded, '...';
+        }
+        $build->log("These files were excluded by the filter stage:");
+        $build->log("excluded $_") for @excluded;
+      }
+      else
+      {
+        $build->log("No files found prior to the filter stage");
+      }
+      die "no matching files in listing";
+    }
     my $version = $res->{list}->[0]->{version};
     my($pick, @other) = map { $_->{url} } @{ $res->{list} };
 


### PR DESCRIPTION
Caveat: the filter stage should not modify the `$res` passed in, but that doesn't actually stop it from doing that :/

before:

```
Alien::Build::Plugin::Core::Download> decoding html
no matching files in listing at /home/ollisg/opt/perl/5.37.5/lib/site_perl/5.37.5/Alien/Build/Plugin/Core/Download.pm line 61.
Recipe did not seem to download a file or directory
```

after:
```
Alien::Build::Plugin::Core::Download> decoding html
Alien::Build::Plugin::Core::Download> These files were excluded by the filter stage:
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/?C=N;O=D
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/?C=M;O=A
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/?C=S;O=A
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/?C=D;O=A
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/README.older-versions
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/make-3.75-3.76.diff.gz
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/make-3.75.tar.gz
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/make-3.76-3.76.1.diff.gz
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/make-3.76.1-3.77.diff.gz
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/make-3.76.1.tar.gz
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/make-3.77.tar.gz
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/make-3.78.1.tar.gz
Alien::Build::Plugin::Core::Download> excluded https://ftp.gnu.org/gnu/make/make-3.79.1.tar.gz
Alien::Build::Plugin::Core::Download> excluded ...
no matching files in listing at /home/ollisg/opt/perl/5.37.5/lib/site_perl/5.37.5/Alien/Build/Plugin/Core/Download.pm line 61.
Recipe did not seem to download a file or directory
```