### PR TITLE
Avoid C99-related errors in expected-compiler-error test

### DIFF
--- a/t/test_alien.t
+++ b/t/test_alien.t
@@ -437,7 +437,15 @@ subtest 'xs_ok' => sub {
     # TODO: test that parsexs error should fail
 
     is(
-      intercept { xs_ok "this should cause a compile error\nMODULE = Foo::Bar PACKAGE = Foo::Bar\n" },
+      intercept { xs_ok q{
+#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+
+#error "this should cause a compile error"
+
+MODULE = Foo::Bar PACKAGE = Foo::Bar
+} },
       array {
         event Ok => sub {
           call pass => F();


### PR DESCRIPTION
This commit supplies the standard XS includes, to avoid triggering implicit ints and implicit functions in the standard code fragments generated by ExtUtils::ParseXS and related tools.

For this test case, this is not a real problem because the compiliation is expected to fail anyway, but the presence of some C99-related errors could mask other issues in the package during future testing.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC