### PR TITLE
Fix to give .runtime.inline_auto_include priority

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Fix inline_auto_include so that it gives priority to
+    the .runtime.inline_auto_include property
 
 2.75      2022-12-21 21:03:27 -0700
   - The Download::Negotiate plugin will no longer pick the

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -875,8 +875,7 @@ property.
 
 sub inline_auto_include {
   my ($class) = @_;
-  return [] unless $class->config('inline_auto_include');
-  $class->runtime_prop->{inline_auto_include} || $class->config('inline_auto_include')
+  $class->runtime_prop->{inline_auto_include} || $class->config('inline_auto_include') || []
 }
 
 sub Inline {


### PR DESCRIPTION
Previous PR at <https://github.com/PerlAlien/Alien-Build/pull/328>.
