### PR TITLE
add arm64- prefix detection

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,37 +18,39 @@ jobs:
       matrix:
         cip:
           - alien_build_install_extra: 1
-            tag: "5.37"
+            tag: "5.39"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.36-alpine3.16"
+            tag: "5.38-alpine3.16"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.36-bionic"
+            tag: "5.38-bionic"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.36-fedora36"
+            tag: "5.38-fedora36"
           - alien_build_install_extra: 0
             env: ALIEN_BUILD_LIVE_TEST=0
-            tag: "5.36-bullseye"
+            tag: "5.38-bullseye"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.36-bullseye"
+            tag: "5.38-bullseye"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=warn
-            tag: "5.36"
+            tag: "5.38"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=digest
-            tag: "5.36"
+            tag: "5.38"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=encrypt
-            tag: "5.36"
+            tag: "5.38"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=digest_or_encrypt
-            tag: "5.36"
+            tag: "5.38"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=digest_and_encrypt
-            tag: "5.36"
+            tag: "5.38"
+          - alien_build_install_extra: 1
+            tag: "5.38"
           - alien_build_install_extra: 1
             tag: "5.36"
           - alien_build_install_extra: 1

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - CPU detection with archname arm64- prefix (gh#411, gh#412)
 
 2.81_01   2023-06-24 09:54:28 -0600
   - Added support for xz compression with

--- a/lib/Alien/Build/Plugin/Core/Setup.pm
+++ b/lib/Alien/Build/Plugin/Core/Setup.pm
@@ -243,6 +243,7 @@ sub _cpu_arch {
     }
   } elsif( $Config{archname} =~ /
       \b aarch64 \b
+    | \b arm64 \b    # arm64-freebsd (FreeBSD can have either aarch64 or arm64)
     /ix ) {
     $arch = { name => 'aarch64' };   # ARM64
   } elsif( $Config{archname} =~ m/


### PR DESCRIPTION
for #411 

apparently archname could use arm64- as a prefix in addition to aarch64- (on FreeBSD anyway)