### PR TITLE
Add rpath to link command in Test::Alien

### DIFF
--- a/lib/Test/Alien.pm
+++ b/lib/Test/Alien.pm
@@ -661,6 +661,7 @@ sub xs_ok
       }
 
       unshift @{ $link_options{extra_linker_flags} }, grep /^-l/, shellwords map { _flags $_, 'libs' } @aliens;
+      push @{ $link_options{extra_linker_flags} }, _rpath( map { _flags $_, 'libs' } @aliens);
 
       my($out, $lib, $err) = capture_merged {
         my $lib = eval {
@@ -788,6 +789,22 @@ sub xs_ok
   }
 
   $ok;
+}
+
+sub _rpath(@)
+{
+  my(@libs) = @_;
+
+  @libs = map { shellwords $_ } @libs;
+  my @rpath;
+  foreach my $lib (@libs)
+  {
+    if($lib =~ /^-L(.*)/)
+    {
+      push @rpath, "-Wl,-rpath,$1";
+    }
+  }
+  @rpath;
 }
 
 sub with_subtest (&)


### PR DESCRIPTION
I am trying to build a shared `libgsl.so` with `Alien::GSL`, see https://github.com/PerlAlien/Alien-GSL/issues/17 for more information. When using an `alienfile` with:

```
  build [
    [ './configure --prefix=%{.install.prefix} --with-pic --enable-shared --disable-static' ],
    [ '%{make}' ],
    [ '%{make} install' ],
  ];
```
`Test::Alien::xs_ok()` gives following error:

```
[...]
t/alien_gsl.t .. 2/? 
# Failed test 'xs'
# at t/alien_gsl.t line 11.
#   XSLoader failed
#     Can't load '/home/dockeruser/Alien-GSL-Shared/_alien/tmp/test-alien-0zwdsb/auto/Test/Alien/XS/Mod0AAAA/Mod0AAAA.so' for module Test::Alien::XS::Mod0AAAA: libgsl.so.28: cannot open shared object file: No such file or directory at /usr/lib/x86_64-linux-gnu/perl-base/DynaLoader.pm line 201.
#  at /home/dockeruser/perl5/lib/perl5/Test/Alien.pm line 483.
# Compilation failed in require at /home/dockeruser/perl5/lib/perl5/Test/Alien.pm line 483.
# BEGIN failed--compilation aborted at /home/dockeruser/perl5/lib/perl5/Test/Alien.pm line 483.
t/alien_gsl.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/3 subtests 
[...]
```
I believe we need to pass the rpath to the linker command to fix this.
