### PR TITLE
Fix some perl-in-space problems

### DIFF
--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -120,7 +120,7 @@ sub init
     $meta->add_requires('configure', 'Alien::Build::Plugin::Build::Autoconf' => '0.41');
     $meta->default_hook(
       build_ffi => [
-        '%{configure} --enable-shared --disable-static --libdir=%{.install.autoconf_prefix}/dynamic',
+        '%{configure} --enable-shared --disable-static "--libdir=%{.install.autoconf_prefix}/dynamic"',
         '%{make}',
         '%{make} install',
       ]
@@ -174,13 +174,14 @@ sub init
           if($build->meta_prop->{out_of_source})
           {
             my $extract = $build->install_prop->{extract};
-            $configure = _win ? "sh $extract/configure" : "$extract/configure";
+            $configure = _win ? qq{sh "$extract/configure"} : "$extract/configure";
           }
           else
           {
             $configure = _win ? 'sh ./configure' : './configure';
           }
-          $configure .= ' --prefix=' . $prefix;
+          $configure .= qq{ "--prefix=$prefix"};
+          $configure .= ' --disable-dependency-tracking';
           $configure .= ' --with-pic' if $self->with_pic;
           $configure;
         }

--- a/t/alien_build_plugin_build_autoconf.t
+++ b/t/alien_build_plugin_build_autoconf.t
@@ -94,7 +94,7 @@ subtest 'out-of-source' => sub {
     my $configure = $build->meta->interpolator->interpolate('%{configure}');
     note "%{configure} = $configure";
 
-    my $regex = $^O eq 'MSWin32' ? qr/^sh (.*?)\s/ : qr/^(.*)\s/;
+    my $regex = $^O eq 'MSWin32' ? qr/^sh "(.*?)"\s/ : qr/^(.*?)\s/;
     like $configure, $regex, 'matches';
 
     if($configure =~ $regex)


### PR DESCRIPTION
While looking at https://github.com/PDLPorters/pdl/issues/498 I wanted to update Alien::proj on my Windows "in space" setup to try to reproduce the problem. The `autoconf` stuff in Alien::sqlite failed. This is a partial fix for that.

This quote-protects the prefix path (where Perl is installed) so `configure` doesn't get the wrong args. It also adds `--disable-dependency-tracking` which seems like it will always be fine, and prevented the next failure, which was in makefile fragments inclusion. The failure after that seems to be because the `autoconf` stuff is getting various compiler components that have spaces in their paths, and putting newlines instead of the spaces. I couldn't find where `configure` was doing that, and have figured out a more idiomatic way to test Proj in any case, so I thought a material improvement was better than nothing.