### PR TITLE
Add is_{system|share}_install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,22 @@ This will return the install type.  (See the like named install property
 above for details).  This method will call `probe` if it has not already
 been called.
 
+## is\_system\_install
+
+```perl
+my $boolean = $build->is_system_install;
+```
+
+Returns true if the alien is a system install type.  
+
+## is\_share\_install
+
+```perl
+my $boolean = $build->is_share_install;
+```
+
+Returns true if the alien is a share install type.  
+
 ## download\_rule
 
 ```perl

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -455,8 +455,15 @@ sub version_cmp {
  my $bool = Alien::MyLibrary->install_type($install_type);
 
 Returns the install type that was used when C<Alien::MyLibrary> was
-installed.  If a type is provided (the second form in the synopsis)
-returns true if the actual install type matches.  Types include:
+installed.  
+
+If a type is provided (the second form in the synopsis)
+returns true if the actual install type matches.  
+For this use case it is recommended to use C<is_system_install> 
+or C<is_share_install> instead as these are less prone to 
+typographical errors.
+
+Types include:
 
 =over 4
 
@@ -479,6 +486,36 @@ sub install_type {
   my $type = $self->config('install_type');
   return @_ ? $type eq $_[0] : $type;
 }
+
+
+=head2 is_system_install
+
+ my $type = $build->is_system_install;
+ 
+Returns true if the alien is a system install type.  
+
+=cut
+
+sub is_system_install
+{
+  my($self) = @_;
+  $self->install_type('system');
+}
+
+=head2 is_share_install
+
+ my $type = $build->is_share_install;
+
+Returns true if the alien is a share install type.  
+
+=cut
+
+sub is_share_install
+{
+  my($self) = @_;
+  $self->install_type('share');
+}
+
 
 sub _pkgconfig_keyword {
   my $self = shift;

--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -948,6 +948,8 @@ sub root
   $root;
 }
 
+=cut
+
 =head2 install_type
 
  my $type = $build->install_type;
@@ -963,6 +965,35 @@ sub install_type
   my($self) = @_;
   $self->{runtime_prop}->{install_type} ||= $self->probe;
 }
+
+=head2 is_system_install
+
+ my $boolean = $build->is_system_install;
+
+Returns true if the alien is a system install type.  
+
+=cut
+
+sub is_system_install
+{
+  my($self) = @_;
+  $self->install_type eq 'system';
+}
+
+=head2 is_share_install
+
+ my $boolean = $build->is_share_install;
+
+Returns true if the alien is a share install type.
+
+=cut
+
+sub is_share_install
+{
+  my($self) = @_;
+  $self->install_type eq 'share';
+}
+
 
 =head2 download_rule
 

--- a/t/alien_base.t
+++ b/t/alien_base.t
@@ -114,6 +114,8 @@ subtest 'Alien::Build system' => sub {
     is( Alien::libfoo1->install_type, 'system' );
     is( Alien::libfoo1->install_type('system'), T() );
     is( Alien::libfoo1->install_type('share'), F() );
+    is( Alien::libfoo1->is_system_install, T() );
+    is( Alien::libfoo1->is_share_install, F() );
   };
 
   is( Alien::libfoo1->config('name'), 'foo', 'config.name' );
@@ -253,6 +255,8 @@ subtest 'Alien::Build share' => sub {
     is( Alien::libfoo2->install_type, 'share' );
     is( Alien::libfoo2->install_type('system'), F() );
     is( Alien::libfoo2->install_type('share'), T() );
+    is( Alien::libfoo2->is_system_install, F() );
+    is( Alien::libfoo2->is_share_install, T() );
   };
 
   is( Alien::libfoo2->config('name'), 'foo', 'config.name' );


### PR DESCRIPTION
This avoids potential typos in code returning false negatives.

I looked for places to add tests for the Alien::Build variants but it was unclear where they should be added.  Potentially `alien_install_type_is` could be adapted to use these methods but it is perhaps best left alone. 

Updates #418 

