### PR TITLE
Modify .pc files in place on Windows

### DIFF
--- a/lib/Alien/Build/Plugin/Build/Autoconf.pm
+++ b/lib/Alien/Build/Plugin/Build/Autoconf.pm
@@ -202,7 +202,9 @@ sub init
             {
               foreach my $pc_file ($pkgconf_dir->children)
               {
-                $pc_file->edit(sub {s/\Q$prefix\E/$real_prefix->stringify/eg;});
+                my $pc_data = $pc_file->slurp;
+                $pc_data =~ s/\Q$prefix\E/$real_prefix->stringify/eg;
+                $pc_file->append({truncate => 1}, $pc_data);
               }
             }
         }


### PR DESCRIPTION
Path::Tiny's `edit` method creates temporary files, which may fail on GitHub's Windows runner images.  Modifying pkg-config style .pc files using `slurp` and `append` works fine. Fixes #425.