### PR TITLE
CPU arch support for illumos

### DIFF
--- a/lib/Alien/Build/Plugin/Core/Setup.pm
+++ b/lib/Alien/Build/Plugin/Core/Setup.pm
@@ -213,6 +213,7 @@ sub _cpu_arch {
     | \b i386 \b   # freebsd-i386
     | \b i486 \b   # i486-linux
     | \b i686 \b   # i686-cygwin
+    | \b i86pc.*64 \b # i86pc-solaris-thread-multi-64
     /ix ) {
     $arch = { name => 'x86' };
   } elsif( $Config{archname} =~ m/


### PR DESCRIPTION
This is to avoid following warning on OpenIndiana:
```
Architecture detection: Unknown archname 'i86pc-solaris-thread-multi-64'. at /usr/perl5/vendor_perl/5.40/Alien/Build/Plugin/Core/Setup.pm line 248.
```