### PR TITLE
Alien::Base::Wrapper: Trust user-specified version numbers of required modules

### DIFF
--- a/lib/Alien/Base/Wrapper.pm
+++ b/lib/Alien/Base/Wrapper.pm
@@ -377,7 +377,7 @@ sub mm_args2
 
   foreach my $module (keys %{ $self->{requires} })
   {
-    $args{CONFIGURE_REQUIRES}->{$module} = $self->{requires}->{$module};
+    $args{CONFIGURE_REQUIRES}->{$module} ||= $self->{requires}->{$module};
   }
 
   %args;

--- a/t/alien_base_wrapper.t
+++ b/t/alien_base_wrapper.t
@@ -261,6 +261,16 @@ subtest 'combine aliens' => sub {
       },
     );
 
+    %mm_args = Alien::Base::Wrapper->mm_args2(
+      CONFIGURE_REQUIRES => {
+        'ExtUtils::MakeMaker'  => '7.12',
+        'Alien::Base::Wrapper' => '0',
+      },
+    );
+
+    is $mm_args{CONFIGURE_REQUIRES}{'ExtUtils::MakeMaker'},  '7.12';
+    is $mm_args{CONFIGURE_REQUIRES}{'Alien::Base::Wrapper'}, '1.97';
+
   };
 
   subtest 'WriteMakefile' => sub {


### PR DESCRIPTION
Resolves #428 by replacing `=` with `||=` in `mm_args2()`.

This proposal assumes that users who specify their own non-zero version numbers in `CONFIGURE_REQUIRES` know what they’re doing. Existing prereq version numbers that are too low are *not* upgraded.
