### PR TITLE
Fix false warning that Download::GitHub is not being used and should.

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for {{$dist->name}}
 {{$NEXT}}
   - Added CPU arch detection support for illumos (Marcel Telka++ gh#427)
   - Add Alien::Build::Meta->has_requires (gh#431)
+  - Fix false warning in Download::Negotiate by detecting Download::GitHub (gh#431)
 
 2.84      2024-10-28 18:51:39 -0600
   - Added is_system_install and is_share_install methods to

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
   - Added CPU arch detection support for illumos (Marcel Telka++ gh#427)
+  - Add Alien::Build::Meta->has_requires (gh#431)
 
 2.84      2024-10-28 18:51:39 -0600
   - Added is_system_install and is_share_install methods to

--- a/README.md
+++ b/README.md
@@ -991,6 +991,15 @@ Add the requirement to the given phase.  Phase should be one of:
 - share
 - system
 
+## has\_requires
+
+```
+if (Alien::Build->meta->has_requires($phase, $module_pat, ...)) {...}
+```
+
+Tests to see if the given phase has any of the given substrings as
+a requirement. Phase as ["add\_requires"](#add_requires).
+
 ## interpolator
 
 ```perl

--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -2149,9 +2149,9 @@ sub has_requires
   while(@_)
   {
     my $pattern = shift;
-    return 1 if grep index($_, $pattern) != -1, @has;
+    for (@has) { return 1 if index($_, $pattern) != -1; }
   }
-  return;
+  return ();
 }
 
 =head2 interpolator

--- a/lib/Alien/Build.pm
+++ b/lib/Alien/Build.pm
@@ -2132,6 +2132,28 @@ sub add_requires
   $self;
 }
 
+=head2 has_requires
+
+ if (Alien::Build->meta->has_requires($phase, $module_pat, ...)) {...}
+
+Tests to see if the given phase has any of the given substrings as
+a requirement. Phase as L</add_requires>.
+
+=cut
+
+sub has_requires
+{
+  my $self = shift;
+  my $phase = shift;
+  my @has = keys %{ $self->{require}->{$phase} };
+  while(@_)
+  {
+    my $pattern = shift;
+    return 1 if grep index($_, $pattern) != -1, @has;
+  }
+  return;
+}
+
 =head2 interpolator
 
  my $interpolator = $build->meta->interpolator;

--- a/lib/Alien/Build/Plugin/Download/Negotiate.pm
+++ b/lib/Alien/Build/Plugin/Download/Negotiate.pm
@@ -247,7 +247,7 @@ sub init
     }
   }
 
-  if($self->url =~ /^http.*github.com.*releases$/)
+  if($self->url =~ /^http.*github.com.*releases$/ && !$meta->has_requires('configure', 'Download::GitHub'))
   {
     Alien::Build->log('!! WARNING !! WARNING !!');
     Alien::Build->log('!! WARNING !! It looks like this alien is using the regular download negotiator');


### PR DESCRIPTION
This will fix #431 and https://github.com/PerlAlien/Alien-Build-Plugin-Download-GitHub/issues/29.