### PR TITLE
use newer CONFIGURE_REQUIRES instead of clobbering

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
             tag: "5.44-bionic"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.44-fedora36"
+            tag: "5.44.0-fedora40"
           - alien_build_install_extra: 0
             env: ALIEN_BUILD_LIVE_TEST=0
             tag: "5.44-bookworm"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,36 +18,40 @@ jobs:
       matrix:
         cip:
           - alien_build_install_extra: 1
-            tag: "5.41"
+            tag: "5.45"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.40-alpine3.16"
+            tag: "5.44-alpine3.16"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.40-bionic"
+            tag: "5.44-bionic"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.40-fedora36"
+            tag: "5.44-fedora36"
           - alien_build_install_extra: 0
             env: ALIEN_BUILD_LIVE_TEST=0
-            tag: "5.40-bullseye"
+            tag: "5.44-bullseye"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.40-bullseye"
+            tag: "5.44-bullseye"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=warn
-            tag: "5.40"
+            tag: "5.44"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=digest
-            tag: "5.40"
+            tag: "5.44"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=encrypt
-            tag: "5.40"
+            tag: "5.44"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=digest_or_encrypt
-            tag: "5.40"
+            tag: "5.44"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=digest_and_encrypt
+            tag: "5.44"
+          - alien_build_install_extra: 1
+            tag: "5.42"
+          - alien_build_install_extra: 1
             tag: "5.40"
           - alien_build_install_extra: 1
             tag: "5.38"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ jobs:
             tag: "5.45"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.44-alpine3.16"
+            tag: "5.44.0-alpine3.20.1"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
             tag: "5.44-bionic"
@@ -30,10 +30,10 @@ jobs:
             tag: "5.44-fedora36"
           - alien_build_install_extra: 0
             env: ALIEN_BUILD_LIVE_TEST=0
-            tag: "5.44-bullseye"
+            tag: "5.44-bookworm"
           - alien_build_install_extra: 1
             env: ALIEN_BUILD_LIVE_TEST=1
-            tag: "5.44-bullseye"
+            tag: "5.44-bookworm"
           - alien_build_install_extra: 1
             env: ALIEN_DOWNLOAD_RULE=warn
             tag: "5.44"

--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Alien::Base::Wrapper->mm_args2 no longer overwrites a caller-specified
+    CONFIGURE_REQUIRES version with its own, lower, requirement.  Instead
+    the newer of the two version numbers is used (gh#428, gh#429,
+    johannessen++)
 
 2.86_05   2026-09-06 12:42:08 -0600
   - additional t/alien_build_plugin_build_cmake.t diagnostic fixes.

--- a/Changes
+++ b/Changes
@@ -3,7 +3,7 @@ Revision history for {{$dist->name}}
 {{$NEXT}}
   - Alien::Base::Wrapper->mm_args2 no longer overwrites a caller-specified
     CONFIGURE_REQUIRES version with its own, lower, requirement.  Instead
-    the newer of the two version numbers is used (gh#428, gh#429,
+    the newer of the two version numbers is used (gh#428, gh#429, gh#439,
     johannessen++)
 
 2.86_05   2026-09-06 12:42:08 -0600

--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@ Revision history for {{$dist->name}}
     CONFIGURE_REQUIRES version with its own, lower, requirement.  Instead
     the newer of the two version numbers is used (gh#428, gh#429, gh#439,
     johannessen++)
+  - Fetch::Wget plugin now treats Wget2 (which some newer Linux
+    distributions ship as /usr/bin/wget in place of GNU Wget) as not
+    found, the same as it already does for the BusyBox wget, since it
+    does not follow the same interface as GNU Wget. (gh#439)
 
 2.86_05   2026-09-06 12:42:08 -0600
   - additional t/alien_build_plugin_build_cmake.t diagnostic fixes.

--- a/lib/Alien/Base/Wrapper.pm
+++ b/lib/Alien/Base/Wrapper.pm
@@ -389,6 +389,8 @@ Returns arguments that you can pass into C<WriteMakefile> to compile/link agains
 a little differently from C<mm_args> above in that you can pass in arguments.  It also adds
 the appropriate C<CONFIGURE_REQUIRES> for you so you do not have to do that explicitly.
 
+[version 2.87]
+
 If you pass in your own C<CONFIGURE_REQUIRES> with a version for a module that this class
 also requires (currently L<ExtUtils::MakeMaker> and C<Alien::Base::Wrapper> itself, plus any
 Alien that you specify a minimum version for), then the newer of the two version numbers

--- a/lib/Alien/Base/Wrapper.pm
+++ b/lib/Alien/Base/Wrapper.pm
@@ -121,6 +121,53 @@ a non-global instance of C<Alien::Base::Wrapper> using the OO interface.
 
 =cut
 
+sub _version_parts
+{
+  my($version) = @_;
+  $version = '0' unless defined $version;
+
+  # dotted-decimal style, e.g. 1.2.3 or v1.2.3: compare each part
+  # separately, as integers.
+  if($version =~ /^v?[0-9]+(\.[0-9]+){2,}$/)
+  {
+    $version =~ s/^v//;
+    return [ split /\./, $version ];
+  }
+
+  # plain decimal style, e.g. 1.00 or 6.52: compare numerically as
+  # a single number, so that (say) 6.6 is newer than 6.52.
+  my($number) = $version =~ /^([0-9]+(?:\.[0-9]+)?)/;
+  $number = 0 unless defined $number;
+  return [ $number ];
+}
+
+sub _version_cmp
+{
+  my($v1, $v2) = @_;
+  my $p1 = _version_parts($v1);
+  my $p2 = _version_parts($v2);
+
+  for my $i (0 .. (@$p1 > @$p2 ? $#$p1 : $#$p2))
+  {
+    my $n1 = defined $p1->[$i] ? $p1->[$i] : 0;
+    my $n2 = defined $p2->[$i] ? $p2->[$i] : 0;
+    my $cmp = $n1 <=> $n2;
+    return $cmp if $cmp;
+  }
+
+  return 0;
+}
+
+# returns whichever of the two version numbers is newer (either may
+# be undef, in which case the other, possibly also undef, is returned).
+sub _version_max
+{
+  my($v1, $v2) = @_;
+  return $v2 unless defined $v1;
+  return $v1 unless defined $v2;
+  return _version_cmp($v1, $v2) >= 0 ? $v1 : $v2;
+}
+
 sub _join
 {
   join ' ',
@@ -342,6 +389,12 @@ Returns arguments that you can pass into C<WriteMakefile> to compile/link agains
 a little differently from C<mm_args> above in that you can pass in arguments.  It also adds
 the appropriate C<CONFIGURE_REQUIRES> for you so you do not have to do that explicitly.
 
+If you pass in your own C<CONFIGURE_REQUIRES> with a version for a module that this class
+also requires (currently L<ExtUtils::MakeMaker> and C<Alien::Base::Wrapper> itself, plus any
+Alien that you specify a minimum version for), then the newer of the two version numbers
+will be used, so that neither requirement is weakened.  Version numbers may be given in
+either decimal (C<1.23>) or dotted-decimal (C<1.2.3>) form.
+
 =cut
 
 sub mm_args2
@@ -377,7 +430,10 @@ sub mm_args2
 
   foreach my $module (keys %{ $self->{requires} })
   {
-    $args{CONFIGURE_REQUIRES}->{$module} = $self->{requires}->{$module};
+    $args{CONFIGURE_REQUIRES}->{$module} = _version_max(
+      $args{CONFIGURE_REQUIRES}->{$module},
+      $self->{requires}->{$module},
+    );
   }
 
   %args;

--- a/lib/Alien/Build/Plugin/Fetch/Wget.pm
+++ b/lib/Alien/Build/Plugin/Fetch/Wget.pm
@@ -55,6 +55,13 @@ sub _wget
   # The wget that BusyBox implements does not follow that same interface
   # as GNU wget and may not check ssl certs which is not good.
   return undef if $output =~ /BusyBox/;
+
+  # Wget2 (which some newer Linux distributions ship as /usr/bin/wget in
+  # place of GNU Wget) does not follow the same interface as GNU Wget either
+  # (in particular its -S output cannot be relied on to include the
+  # Content-Type header), so treat it as not found, same as BusyBox.
+  return undef if $output =~ /GNU Wget2/;
+
   return $wget;
 }
 

--- a/maint/cip-before-install
+++ b/maint/cip-before-install
@@ -2,6 +2,8 @@
 
 set -ex
 
+SKIP_LIBPKGCONF=0
+
 if echo $CIP_TAG | grep -q -- -alpine ; then
   echo alpine
   cip sudo apk add cmake
@@ -10,6 +12,10 @@ if echo $CIP_TAG | grep -q -- -alpine ; then
   # needed for plugin tests later
   cip sudo apk add git
   cip sudo apk add g++
+  # pkgconf-dev on alpine3.20.1 is pkgconf 2.2.0, whose libpkgconf changed
+  # the pkgconf_pkg_new_from_file signature, breaking the XS build of
+  # PkgConfig::LibPkgConf 0.11 (gh#439)
+  SKIP_LIBPKGCONF=1
 elif echo $CIP_TAG | grep -q -- -fedora ; then
   echo Fedora
   cip sudo yum install cmake libffi-devel wget git g++ -y
@@ -23,32 +29,38 @@ if [ "x$ALIEN_BUILD_INSTALL_EXTRA" == "x1" ]; then
 
   cip exec env PERL_ALT_INSTALL=OVERWRITE cpanm -n Alt::Alien::cmake3::System
 
-  cip exec cpanm -n \
-    Test2::Harness \
-    File::Listing \
-    File::Listing::Ftpcopy \
-    HTML::LinkExtor \
-    HTTP::Tiny \
-    LWP \
-    PkgConfig \
-    PkgConfig::LibPkgConf \
-    Sort::Versions \
-    URI \
-    YAML \
-    Env::ShellWords \
-    Archive::Tar \
-    Archive::Zip \
-    Devel::Hide \
-    Readonly \
-    Alien::Base::ModuleBuild \
-    FFI::Platypus \
-    Mojo::DOM58 \
-    Mojolicious \
-    Win32::Vcpkg \
-    Plack \
-    Proc::Daemon \
-    AnyEvent::FTP \
+  MODULES="
+    Test2::Harness
+    File::Listing
+    File::Listing::Ftpcopy
+    HTML::LinkExtor
+    HTTP::Tiny
+    LWP
+    PkgConfig
+    Sort::Versions
+    URI
+    YAML
+    Env::ShellWords
+    Archive::Tar
+    Archive::Zip
+    Devel::Hide
+    Readonly
+    Alien::Base::ModuleBuild
+    FFI::Platypus
+    Mojo::DOM58
+    Mojolicious
+    Win32::Vcpkg
+    Plack
+    Proc::Daemon
+    AnyEvent::FTP
     Digest::SHA::PurePerl
+  "
+
+  if [ "x$SKIP_LIBPKGCONF" != "x1" ]; then
+    MODULES="$MODULES PkgConfig::LibPkgConf"
+  fi
+
+  cip exec cpanm -n $MODULES
 
 fi
 

--- a/t/alien_base_wrapper.t
+++ b/t/alien_base_wrapper.t
@@ -26,6 +26,19 @@ sub exec_arrayref (&)
   \@answer;
 }
 
+subtest '_version_max' => sub {
+
+  is Alien::Base::Wrapper::_version_max(undef, undef),    U(),     'undef, undef';
+  is Alien::Base::Wrapper::_version_max(undef, '1.97'),   '1.97',  'undef, defined';
+  is Alien::Base::Wrapper::_version_max('1.97', undef),   '1.97',  'defined, undef';
+  is Alien::Base::Wrapper::_version_max('6.52', '7.12'),  '7.12',  'decimal: newer wins';
+  is Alien::Base::Wrapper::_version_max('1.97', '0'),     '1.97',  'decimal: zero loses to nonzero';
+  is Alien::Base::Wrapper::_version_max('6.52', '6.10'),  '6.52',  'decimal: 6.10 is numerically 6.1, older than 6.52';
+  is Alien::Base::Wrapper::_version_max('1.2.3', '1.10.0'), '1.10.0', 'dotted-decimal: compared part by part';
+  is Alien::Base::Wrapper::_version_max('1.00', '1.2.3'), '1.2.3', 'decimal vs dotted-decimal';
+
+};
+
 subtest 'export' => sub {
 
   {
@@ -259,6 +272,31 @@ subtest 'combine aliens' => sub {
           field 'Alien::Foo5'          => '0';
         };
       },
+    );
+
+  };
+
+  subtest 'mm_args2 CONFIGURE_REQUIRES keeps the newer version' => sub {
+
+    my %mm_args = Alien::Base::Wrapper->mm_args2(
+      CONFIGURE_REQUIRES => {
+        'ExtUtils::MakeMaker'  => '7.12',  # newer than the 6.52 we require
+        'Alien::Base::Wrapper' => '0',     # older ("any version") than the 1.97 we require
+        'Alien::Bar5'          => '1.10',  # older than the 1.23 we require
+      },
+    );
+
+    note _dump(\%mm_args);
+
+    is(
+      $mm_args{CONFIGURE_REQUIRES},
+      hash {
+        field 'ExtUtils::MakeMaker'  => '7.12';
+        field 'Alien::Base::Wrapper' => '1.97';
+        field 'Alien::Bar5'          => '1.23';
+        field 'Alien::Foo5'          => '0';
+      },
+      'the newer of the two versions wins in each case',
     );
 
   };


### PR DESCRIPTION
…RES version

mm_args2() previously always overwrote a caller-specified CONFIGURE_REQUIRES version with its own required version, even if the caller's was higher (gh#428). Rather than simply preferring the caller's value (as proposed in gh#429), pick whichever of the two versions is newer, using a small pure-Perl comparator that supports both decimal (1.23) and dotted-decimal (1.2.3) version strings, with no non-core dependencies.


Claude-Session: https://claude.ai/code/session_01PD59r5VDdEpwo1QFVJPebY